### PR TITLE
Fix `LoadCHKData`

### DIFF
--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -217,19 +217,16 @@ Namespace ProjectSet
                         Exit Sub
                     End If
 
+                    Try
+                        mem.Position = SearchCHK("WAV ", buffer)
 
-                    mem.Position = SearchCHK("WAV ", buffer)
-
-                    size = binary.ReadUInt32
-                    For i = 0 To size / 4 - 1
-                        'binary.ReadUInt32()
-                        '    binary.ReadUInt32()
-                        '    binary.ReadUInt32()
-                        '    binary.ReadUInt32()
-
-                        CHKWAVLIST.Add(binary.ReadUInt32())
-                        '    binary.ReadUInt16()
-                    Next
+                        size = binary.ReadUInt32
+                        For i = 0 To size / 4 - 1
+                            CHKWAVLIST.Add(binary.ReadUInt32())
+                        Next
+                    Catch ex As Exception
+                        Exit Try
+                    End Try
 
                     Dim _playerFlag(8) As Boolean
                     mem.Position = SearchCHK("OWNR", buffer)

--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -146,11 +146,6 @@ Namespace ProjectSet
         End Function
 
 
-
-
-
-
-
         Public Sub LoadCHKdata()
             LoadTILEDATA()
 
@@ -163,8 +158,6 @@ Namespace ProjectSet
 
             Dim key As String
 
-
-
             For i = 0 To DatEditDATA.Count - 1
                 For j = 0 To DatEditDATA(i).mapdata.Count - 1
                     For p = 0 To DatEditDATA(i).mapdata(j).Count - 1
@@ -172,10 +165,6 @@ Namespace ProjectSet
                     Next
                 Next
             Next
-
-
-
-
 
             Dim hmpq As UInteger
             Dim hfile As UInteger
@@ -186,7 +175,6 @@ Namespace ProjectSet
             Dim pdwread As IntPtr
 
             StormLib.SFileOpenArchive(InputMap, 0, 0, hmpq)
-
 
             Dim openFilename As String = "staredit\scenario.chk"
 
@@ -201,24 +189,6 @@ Namespace ProjectSet
                 Dim mem As MemoryStream = New MemoryStream(buffer)
                 Dim binary As BinaryReader = New BinaryReader(mem)
                 Dim stream As StreamReader = New StreamReader(mem, Text.Encoding.ASCII)
-
-                Try
-                    mem.Position = SearchCHK("TYPE", buffer)
-                Catch ex As Exception
-                    LoadFromCHK = False
-                    Exit Sub
-                End Try
-
-                size = binary.ReadUInt32
-
-                Dim value As UInteger = binary.ReadUInt32
-                If (value <> 1113014610) Then
-                    LoadFromCHK = False
-                    Exit Sub
-                End If
-
-
-
 
                 mem.Position = SearchCHK("SIDE", buffer)
 

--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -286,12 +286,16 @@ Namespace ProjectSet
                         binary.ReadUInt16()
                     Next
 
-                    mem.Position = SearchCHK("SWNM", buffer)
-
-                    size = binary.ReadUInt32
-                    For i = 0 To 255
-                        CHKSWITCHNAME.Add(binary.ReadUInt32)
-                    Next
+                    Try
+                        mem.Position = SearchCHK("SWNM", buffer)
+                    Catch ex As Exception
+                        Exit Try
+                    Finally
+                        size = binary.ReadUInt32
+                        For i = 0 To 255
+                            CHKSWITCHNAME.Add(binary.ReadUInt32)
+                        Next
+                    End Try
 
 
                     mem.Position = SearchCHK("UPGx", buffer)


### PR DESCRIPTION
Best to review commit by commit

- Don't read optional chk sections: TYPE, WAV, SWNM
- Handle invalid string offsets instead of raising EndOfStreamException