### PR TITLE
Triggers: add null terminator for DBText

### DIFF
--- a/EUD Editor/Module/Trigger.vb
+++ b/EUD Editor/Module/Trigger.vb
@@ -607,7 +607,7 @@ Public Class Element
                 End If
             Case "DBText"
                 If isTocode = True Then
-                    returnstring = "Db(u2utf8(" & returnstring & "))"
+                    returnstring = "Db(" & returnstring & ")"
 
                     Return returnstring
                 End If

--- a/EUD Editor/Module/Trigger.vb
+++ b/EUD Editor/Module/Trigger.vb
@@ -592,12 +592,7 @@ Public Class Element
                 End If
             Case "Location"
                 If isTocode = True And isnumber = True Then
-                    Try
-                        returnstring -= 1
-                        Return returnstring
-                    Catch ex As Exception
-
-                    End Try
+                    Return returnstring
                 End If
             Case "CText"
                 If isTocode = True Then


### PR DESCRIPTION
Db("str") is Db(u2utf8("str\0"))