### PR TITLE
Fixed extra eds settings bug 

### DIFF
--- a/EUD Editor/Module/parsingModule.vb
+++ b/EUD Editor/Module/parsingModule.vb
@@ -357,7 +357,7 @@ Module parsingModule
                 'If key = "extraedssetting" Then
                 '    MsgBox(InStr(text, vbCrLf) - key.Count - 4)
                 'End If
-                If InStr(text, vbCrLf) = 0 Then
+                If InStr(text, vbCrLf) = 0 Or key = "extraedssetting" Then
                     Return Mid(text, key.Count + 4)
                 Else
                     Return Mid(text, key.Count + 4, InStr(text, vbCrLf) - key.Count - 4)


### PR DESCRIPTION
The bug: everything beyond the first linebreak in "extraedssetting" getting removed.
The bug specifically happens when the base map file location is invalid (idk why it doesn't happen when it's valid though, I can't find a logical reason why they're affecting each other.)