### PR TITLE
EUD Editor 2 SE 0.18.1.5

### DIFF
--- a/EUD Editor/Data/TriggerEditor/condition.json
+++ b/EUD Editor/Data/TriggerEditor/condition.json
@@ -397,7 +397,7 @@
     "Name": "MemoryX",
     "Texts": [
       "Korean",
-      "메모리 주소 $Offset$의 값이 $Comparison$ $Number$ 이라면 (비트마스크: $Bitmask)",
+      "메모리 주소 $Offset$의 값이 $Comparison$ $Number$ 이라면 ( 비트마스크: $Bitmask$ )",
       "English",
       "Memory at $Offset$ is $Comparison$ $Number$ with $Bitmask$."
     ],
@@ -414,7 +414,7 @@
     "Name": "MemoryXEPD",
     "Texts": [
       "Korean",
-      "메모리 주소 EPD $Epd$의 값이 $Comparison$ $Number$ 이라면 (비트마스크: $Bitmask)",
+      "메모리 주소 EPD $Epd$의 값이 $Comparison$ $Number$ 이라면 ( 비트마스크: $Bitmask$ )",
       "English",
       "Memory at Death Table (+-) $Epd$ is $Comparison$ $Number$ with $Bitmask$."
     ],

--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -9,7 +9,7 @@ Namespace ProgramSet
 
 
         'Public Version As String = "vTEST 0.13"
-        Public Version As String = "0.18.1.4"
+        Public Version As String = "0.18.1.5"
         Public DatEditVersion As String = "v0.3"
         Public SCDBSerial As UInteger
 

--- a/version/PatchNote
+++ b/version/PatchNote
@@ -1,3 +1,8 @@
+[ Patch notes 0.18.1.5 ]
+
+- Autodetect CP949/UTF-8 for map string encoding
+- Fixed typos in MemoryX, MemoryXEPD conditions in Korean (reported by 페제짱)
+
 [ Patch notes 0.18.1.4 ]
 
 - Fixed typos in TEFunction (reported by 리아님)

--- a/version/version
+++ b/version/version
@@ -1,2 +1,2 @@
-0.18.1.4
-https://github.com/iDoodler-DS/EUDEditor/releases/download/v0.18.1.4/EUD.EditorSE2.0.18.1.4.zip
+0.18.1.5
+https://github.com/iDoodler-DS/EUDEditor/releases/download/v0.18.1.5/EUD.EditorSE2.0.18.1.5.zip


### PR DESCRIPTION
- Autodetect CP949/UTF-8 map string encoding
- Fixed `MemoryX`, `MemoryXEPD` typos in Korean settings (reported by 페제짱)