### PR TITLE
Use SetKills euddraft built-in action

### DIFF
--- a/EUD Editor/Data/TriggerEditor/action.json
+++ b/EUD Editor/Data/TriggerEditor/action.json
@@ -1024,7 +1024,7 @@
       "English",
       "Modify $Unit$ Kills: $Modifier$ $Number$ for $PlayerX$"
     ],
-    "CodeText": "SetMemoryEPD(EPD(0x5878A4) + $PlayerX$ + ($Unit$) * 12, $Modifier$, $Number$)",
+    "CodeText": "SetKills($PlayerX$, $Modifier$, $Number$, $Unit$)",
     "ToolTip": "None",
     "ValuesDef": [
       "PlayerX",


### PR DESCRIPTION
Let `SetKills` action raise compile error when Unit is Any unit/Men/Buildings/Factories.
There is no `SetKills` action in Trigger. We can modify kills table with EUD but kills table only exists for unit id 0~227.
Kills of Any unit/Men/Buildings/Factories are calculated differently and we can't change it with EUD.
But users can increment number to compare for kills detection.
```js
if (Player) kills (AtLeast) (X) (Men).
Then -> Increase (X) by (1).
```