### PR TITLE
EE2 SE 0.18.1.7

### DIFF
--- a/EUD Editor/Data/TriggerEditor/action.json
+++ b/EUD Editor/Data/TriggerEditor/action.json
@@ -1024,7 +1024,7 @@
       "English",
       "Modify $Unit$ Kills: $Modifier$ $Number$ for $PlayerX$"
     ],
-    "CodeText": "SetMemoryEPD(EPD(0x5878A4) + $PlayerX$ + ($Unit$) * 12, $Modifier$, $Number$)",
+    "CodeText": "SetKills($PlayerX$, $Modifier$, $Number$, $Unit$)",
     "ToolTip": "None",
     "ValuesDef": [
       "PlayerX",

--- a/EUD Editor/Data/TriggerEditor/action.json
+++ b/EUD Editor/Data/TriggerEditor/action.json
@@ -988,7 +988,7 @@
     "Name": "SetDeathsX",
     "Texts": [
       "Korean",
-      "$Player$의 $Unit$가 죽은 수를 $Number$만큼 $Modifier$합니다. 비트마스크: $Bitmask",
+      "$Player$의 $Unit$가 죽은 수를 $Number$만큼 $Modifier$합니다. 비트마스크: $Bitmask$",
       "English",
       "Modify death counts for $Player$: $Modifier$ $Number$ for $Unit$ with $Bitmask$."
     ],

--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -2123,8 +2123,13 @@ Namespace ProjectSet
 
 
             _stringbdl.Append("S_TileSET" & vbCrLf)
-            _stringbdl.Append("ProjectTileUseFile : " & ProjectTileUseFile & vbCrLf)
-            _stringbdl.Append("ProjectTileSetFileName : " & ProjectTileSetFileName & vbCrLf)
+            If ProjectTileUseFile Is Nothing OrElse ProjectTileUseFile Is False Then
+                _stringbdl.Append("ProjectTileUseFile : " & False & vbCrLf)
+                _stringbdl.Append("ProjectTileSetFileName : " & vbCrLf)
+            Else
+                _stringbdl.Append("ProjectTileUseFile : " & ProjectTileUseFile & vbCrLf)
+                _stringbdl.Append("ProjectTileSetFileName : " & ProjectTileSetFileName & vbCrLf)
+            End If
             _stringbdl.Append("ProjectTIleMSetCount : " & ProjectTIleMSet.Count & vbCrLf)
 
             Dim ProjectTIleMSetArray As String = ""

--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -8,7 +8,7 @@ Namespace ProgramSet
         Public FireGraftName As String = "FireGraft in EUDEditor"
 
 
-        Public Version As String = "0.18.1.6"
+        Public Version As String = "0.18.1.7"
         Public DatEditVersion As String = "v0.3"
         Public SCDBSerial As UInteger
 

--- a/EUD Editor/Module/SettingModule.vb
+++ b/EUD Editor/Module/SettingModule.vb
@@ -2123,7 +2123,7 @@ Namespace ProjectSet
 
 
             _stringbdl.Append("S_TileSET" & vbCrLf)
-            If ProjectTileUseFile Is Nothing OrElse ProjectTileUseFile Is False Then
+            If (ProjectTileUseFile Is Nothing) OrElse (Not ProjectTileUseFile) Then
                 _stringbdl.Append("ProjectTileUseFile : " & False & vbCrLf)
                 _stringbdl.Append("ProjectTileSetFileName : " & vbCrLf)
             Else

--- a/EUD Editor/Module/eudplibModule.vb
+++ b/EUD Editor/Module/eudplibModule.vb
@@ -1028,7 +1028,7 @@ Namespace eudplib
             If isedd = True Then
                 filename = basefolder & "\eudplibdata\EUDEditor.edd"
                 filestream = New FileStream(filename, FileMode.Create)
-                streamwriter = New StreamWriter(filestream, Encoding.GetEncoding("ks_c_5601-1987"))
+                streamwriter = New StreamWriter(filestream) ', Encoding.GetEncoding("ks_c_5601-1987"))
 
                 streamwriter.Write(Getedstext)
                 streamwriter.Close()

--- a/version/PatchNote
+++ b/version/PatchNote
@@ -1,3 +1,10 @@
+[ Patch notes 0.18.1.7 ]
+
+- SetKills action now uses eudplib built-in SetKills action
+- Fixed encoding of .edd file from CP949 to UTF-8
+- Fixed error when saving. System.ArgumentNullException: Value cannot be null. Parameter name: source
+- Fixed typos in SetDeathsX action in Korean
+
 [ Patch notes 0.18.1.6 ]
 
 - Added [main] extra option in plugin (contributed by @Dr-zzt)

--- a/version/version
+++ b/version/version
@@ -1,2 +1,2 @@
-0.18.1.6
-https://github.com/iDoodler-DS/EUDEditor/releases/download/v0.18.1.6/EUD.EditorSE2.0.18.1.6.zip
+0.18.1.7
+https://github.com/iDoodler-DS/EUDEditor/releases/download/v0.18.1.7/EUD.EditorSE2.0.18.1.7.zip


### PR DESCRIPTION
- SetKills action now uses eudplib built-in SetKills action
- Fixed encoding of .edd file from CP949 to UTF-8
- Fixed error when saving. System.ArgumentNullException: Value cannot be null. Parameter name: source
- Fixed typos in SetDeathsX action in Korean